### PR TITLE
Handle bank feed HTTP 400 error with missing fields

### DIFF
--- a/xero/exceptions.py
+++ b/xero/exceptions.py
@@ -29,7 +29,7 @@ class XeroBadRequest(XeroException):
     def __init__(self, response):
         if response.headers["content-type"].startswith("application/json"):
             data = json.loads(response.text)
-            msg = "%s: %s" % (data["Type"], data["Message"])
+            msg = "%s: %s" % (data.get("Type", "Unknown"), data.get("Message", "Not provided"))
             self.errors = [
                 err["Message"]
                 for elem in data.get("Elements", [])


### PR DESCRIPTION
Sometimes Bank Feed API calls fail with a HTTP 400 status code but the exception manager cannot handle it. The PR attempts to handle these failed calls more gracefully.

```Traceback (most recent call last):
  File "/usr/local/lib/python3.6/code.py", line 91, in runcode
    exec(code, self.locals)
  File "<console>", line 1, in <module>
  File "/app/.venv/lib/python3.6/site-packages/xero/bankfeedsmanager.py", line 84, in wrapper
    raise XeroBadRequest(response)
  File "/app/.venv/lib/python3.6/site-packages/xero/exceptions.py", line 32, in __init__
    msg = "%s: %s" % (data["Type"], data["Message"])
KeyError: 'Type'```